### PR TITLE
Bypass browser enforcement with novalidate

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
                 </svg>
             </div>
             <h1>Create an experiment</h1>
-            <form>
+            <form novalidate>
                 <div class="lego-form__header">
                     <div class="lego-form__title">Experiment-level details</div>
                 </div>


### PR DESCRIPTION
In Chrome a blocking "Please Fill out this field" modal/tooltip appears and blocks submission due to the default HTML5 form behavior in the browser. By including this flag on the form we can rely on the implemented creation logic and not be blocked from using less than specified number of headlines.